### PR TITLE
Adding sleep to fix service restart issue

### DIFF
--- a/debian/salt-eventsd.init.d
+++ b/debian/salt-eventsd.init.d
@@ -106,6 +106,7 @@ case "$1" in
         do_stop
         case "$?" in
           0|1)
+              sleep 1
               do_start
               case "$?" in
                   0) log_end_msg 0 ;;


### PR DESCRIPTION
Restarting the service always failed...the service stopped successfully but failed to restart. As the stop is simply sending a signal to the process and not waiting to see if the process terminates, I assumed it was a timing issue between handling the signal and exiting gracefully and the new process starting up. Adding a sleep of one second allows the new process to start successfully. 
